### PR TITLE
refactor: share app store defaults

### DIFF
--- a/apps/backend-electron/src/vendor/ElectronStore.ts
+++ b/apps/backend-electron/src/vendor/ElectronStore.ts
@@ -1,6 +1,9 @@
 import { provide } from "@inversifyjs/binding-decorators";
-import { AppLanguage, AppTheme } from "@mediago/shared-common";
-import type { AppStore } from "@mediago/shared-node";
+import {
+  appStoreDefaults,
+  appStoreSharedOptions,
+  type AppStore,
+} from "@mediago/shared-node";
 import Store from "electron-store";
 import { injectable } from "inversify";
 import { download, workspace } from "../helper/index";
@@ -10,33 +13,12 @@ import { download, workspace } from "../helper/index";
 export default class StoreService extends Store<AppStore> {
   constructor() {
     super({
+      ...appStoreSharedOptions,
       name: "config",
       cwd: workspace,
-      fileExtension: "json",
-      watch: true,
       defaults: {
+        ...appStoreDefaults,
         local: download,
-        promptTone: true,
-        proxy: "",
-        useProxy: false,
-        deleteSegments: true,
-        openInNewWindow: false,
-        blockAds: true,
-        theme: AppTheme.System,
-        useExtension: false,
-        isMobile: false,
-        maxRunner: 2,
-        language: AppLanguage.System,
-        showTerminal: false,
-        privacy: false,
-        machineId: "",
-        downloadProxySwitch: false,
-        autoUpgrade: true,
-        allowBeta: false,
-        closeMainWindow: false,
-        audioMuted: true,
-        enableDocker: false,
-        dockerUrl: "",
       },
     });
   }

--- a/apps/backend-web/src/vendor/Store.ts
+++ b/apps/backend-web/src/vendor/Store.ts
@@ -1,6 +1,9 @@
 import { provide } from "@inversifyjs/binding-decorators";
-import { AppLanguage, AppTheme } from "@mediago/shared-common";
-import type { AppStore } from "@mediago/shared-node";
+import {
+  appStoreDefaults,
+  appStoreSharedOptions,
+  type AppStore,
+} from "@mediago/shared-node";
 import Conf from "conf";
 import { injectable } from "inversify";
 import { DOWNLOAD_DIR, WORKSPACE } from "../helper/variables";
@@ -10,33 +13,12 @@ import { DOWNLOAD_DIR, WORKSPACE } from "../helper/variables";
 export default class StoreService extends Conf<AppStore> {
   constructor() {
     super({
+      ...appStoreSharedOptions,
       projectName: "config",
       cwd: WORKSPACE,
-      fileExtension: "json",
-      watch: true,
       defaults: {
+        ...appStoreDefaults,
         local: DOWNLOAD_DIR,
-        promptTone: true,
-        proxy: "",
-        useProxy: false,
-        deleteSegments: true,
-        openInNewWindow: false,
-        blockAds: true,
-        theme: AppTheme.System,
-        useExtension: false,
-        isMobile: false,
-        maxRunner: 2,
-        language: AppLanguage.System,
-        showTerminal: false,
-        privacy: false,
-        machineId: "",
-        downloadProxySwitch: false,
-        autoUpgrade: true,
-        allowBeta: false,
-        closeMainWindow: false,
-        audioMuted: true,
-        enableDocker: false,
-        dockerUrl: "",
       },
     });
   }

--- a/packages/shared-node/src/config/appStoreDefaults.ts
+++ b/packages/shared-node/src/config/appStoreDefaults.ts
@@ -1,0 +1,37 @@
+import { AppLanguage, AppTheme } from "@mediago/shared-common";
+import type { AppStore } from "../types/index";
+
+export interface AppStoreSharedOptions {
+  fileExtension: string;
+  watch: boolean;
+}
+
+export const appStoreSharedOptions: AppStoreSharedOptions = {
+  fileExtension: "json",
+  watch: true,
+};
+
+export const appStoreDefaults: AppStore = {
+  local: "",
+  promptTone: true,
+  proxy: "",
+  useProxy: false,
+  deleteSegments: true,
+  openInNewWindow: false,
+  blockAds: true,
+  theme: AppTheme.System,
+  useExtension: false,
+  isMobile: false,
+  maxRunner: 2,
+  language: AppLanguage.System,
+  showTerminal: false,
+  privacy: false,
+  machineId: "",
+  downloadProxySwitch: false,
+  autoUpgrade: true,
+  allowBeta: false,
+  closeMainWindow: false,
+  audioMuted: true,
+  enableDocker: false,
+  dockerUrl: "",
+};

--- a/packages/shared-node/src/index.ts
+++ b/packages/shared-node/src/index.ts
@@ -3,3 +3,4 @@ export * from "./services/index";
 export * from "./types/index";
 export * from "./vendor/index";
 export * from "./utils/index";
+export * from "./config/appStoreDefaults";


### PR DESCRIPTION
## Summary
- add shared app store defaults and option shape to @mediago/shared-node
- refactor Electron and web store services to consume the shared defaults while preserving platform-specific overrides
- expose the shared config exports through the shared-node package entry point

## Testing
- pnpm --filter @mediago/shared-node types
- pnpm --filter backend-electron types
- pnpm --filter backend-web types

------
https://chatgpt.com/codex/tasks/task_e_68d28454425c832baf49439417785d6a