### PR TITLE
Refactor app store handler mapping

### DIFF
--- a/apps/backend-electron/src/__mocks__/electron-is-dev.ts
+++ b/apps/backend-electron/src/__mocks__/electron-is-dev.ts
@@ -1,0 +1,1 @@
+export default false;

--- a/apps/backend-electron/src/__mocks__/electron-store.ts
+++ b/apps/backend-electron/src/__mocks__/electron-store.ts
@@ -1,0 +1,19 @@
+export interface StoreOptions<T> {
+  defaults: T;
+}
+
+export default class Store<T> {
+  public readonly store: T;
+
+  constructor(options: StoreOptions<T>) {
+    this.store = options.defaults;
+  }
+
+  get<K extends keyof T>(key: K): T[K] {
+    return this.store[key];
+  }
+
+  set<K extends keyof T>(key: K, value: T[K]): void {
+    (this.store as Record<string, unknown>)[key as string] = value as unknown;
+  }
+}

--- a/apps/backend-electron/src/__mocks__/electron-updater.ts
+++ b/apps/backend-electron/src/__mocks__/electron-updater.ts
@@ -1,0 +1,5 @@
+export const autoUpdater = {
+  checkForUpdates: async () => undefined,
+  on: (_event: string, _listener: (...args: unknown[]) => void) => undefined,
+  setFeedURL: (_options: unknown) => undefined,
+};

--- a/apps/backend-electron/src/__mocks__/electron.ts
+++ b/apps/backend-electron/src/__mocks__/electron.ts
@@ -1,0 +1,149 @@
+export type IpcMainEvent = {
+  sender?: { send: (channel: string, data: unknown) => void };
+};
+
+export const clipboard = {
+  writeText: (_text: string) => undefined,
+};
+
+export const dialog = {
+  async showOpenDialog(): Promise<{ canceled: boolean; filePaths: string[] }> {
+    return { canceled: true, filePaths: [] };
+  },
+};
+
+export class MenuItem {}
+
+export type MenuItemConstructorOptions = {
+  label?: string;
+  type?: "separator";
+  click?: () => void;
+};
+
+export class Menu {
+  static buildFromTemplate(_template: Array<MenuItemConstructorOptions | MenuItem>) {
+    return new Menu();
+  }
+
+  popup(): void {
+    // no-op
+  }
+}
+
+export const nativeTheme = {
+  themeSource: "system" as string,
+};
+
+export const shell = {
+  async openPath(_dir: string): Promise<string> {
+    return "";
+  },
+  async openExternal(_url: string): Promise<void> {
+    // no-op
+  },
+};
+
+export const app = {
+  getAppPath(): string {
+    return process.cwd();
+  },
+  getPath(_name: string): string {
+    return process.cwd();
+  },
+  whenReady(): Promise<void> {
+    return Promise.resolve();
+  },
+  on(_event: string, _handler: (...args: unknown[]) => void): void {
+    // no-op
+  },
+};
+
+export interface BrowserWindowConstructorOptions {
+  [key: string]: unknown;
+}
+
+export class BrowserWindow {
+  public webContents = {
+    openDevTools: () => undefined,
+    on: (_event: string, _listener: (...args: unknown[]) => void) => undefined,
+    stop: () => undefined,
+    loadURL: (_url: string) => Promise.resolve(),
+    getTitle: () => "",
+    getURL: () => "",
+    setWindowOpenHandler: (_handler: (...args: unknown[]) => unknown) => ({
+      action: "deny" as const,
+    }),
+    send: (_channel: string, _data: unknown) => undefined,
+  };
+
+  public contentView = {
+    addChildView: (_view: unknown) => undefined,
+    removeChildView: (_view: unknown) => undefined,
+  };
+
+  loadURL(_url: string): Promise<void> {
+    return Promise.resolve();
+  }
+
+  once(_event: string, _listener: (...args: unknown[]) => void): void {}
+
+  on(_event: string, _listener: (...args: unknown[]) => void): void {}
+
+  show(): void {}
+
+  hide(): void {}
+
+  close(): void {}
+
+  getBounds(): { x: number; y: number; width: number; height: number } {
+    return { x: 0, y: 0, width: 0, height: 0 };
+  }
+
+  setBounds(_bounds: { x: number; y: number; width: number; height: number }): void {}
+
+  setBackgroundColor(_color: string): void {}
+}
+
+export class Notification {
+  show(): void {}
+}
+
+export class WebContentsView {
+  public webContents = {
+    openDevTools: () => undefined,
+    on: (_event: string, _listener: (...args: unknown[]) => void) => undefined,
+    stop: () => undefined,
+    loadURL: (_url: string) => Promise.resolve(),
+    getTitle: () => "",
+    getURL: () => "",
+    setWindowOpenHandler: (_handler: (...args: unknown[]) => unknown) => ({
+      action: "deny" as const,
+    }),
+    send: (_channel: string, _data: unknown) => undefined,
+    executeJavaScript: async (_code: string) => undefined,
+    setAudioMuted: (_muted: boolean) => undefined,
+    setUserAgent: (_agent: string) => undefined,
+  };
+
+  setBackgroundColor(_color: string): void {}
+
+  setBounds(_bounds: { x: number; y: number; width: number; height: number }): void {}
+}
+
+export interface HandlerDetails {
+  url: string;
+}
+
+export interface Event {
+  preventDefault(): void;
+}
+
+const mockSession = {
+  setProxy: async (_config: { proxyRules: string }) => undefined,
+  clearCache: async () => undefined,
+  clearStorageData: async () => undefined,
+};
+
+export const session = {
+  fromPartition: (_partition: string) => mockSession,
+};

--- a/apps/backend-electron/src/__mocks__/fs-extra.ts
+++ b/apps/backend-electron/src/__mocks__/fs-extra.ts
@@ -1,0 +1,10 @@
+const fsExtra = {
+  exists: async (_path: string): Promise<boolean> => false,
+  writeFile: async (_path: string, _data: string): Promise<void> => undefined,
+  readJSON: async (_path: string): Promise<unknown> => ({}),
+  readFileSync: (_path: string, _encoding: string): string => "",
+};
+
+export default fsExtra;
+
+export const readFileSync = fsExtra.readFileSync;

--- a/apps/backend-electron/src/__mocks__/node-machine-id.ts
+++ b/apps/backend-electron/src/__mocks__/node-machine-id.ts
@@ -1,0 +1,3 @@
+export async function machineId(): Promise<string> {
+  return "mock-machine-id";
+}

--- a/apps/backend-electron/src/__mocks__/shared-node.ts
+++ b/apps/backend-electron/src/__mocks__/shared-node.ts
@@ -1,0 +1,79 @@
+import type { AppLanguage, AppTheme } from "@mediago/shared-common";
+
+export interface EnvPath {
+  binPath: string;
+  dbPath: string;
+  workspace: string;
+  platform: string;
+  local: string;
+}
+
+export interface Favorite {
+  id: number;
+  name: string;
+  url: string;
+}
+
+export interface AppStore {
+  local: string;
+  promptTone: boolean;
+  proxy: string;
+  useProxy: boolean;
+  deleteSegments: boolean;
+  openInNewWindow: boolean;
+  mainBounds?: unknown;
+  browserBounds?: unknown;
+  blockAds: boolean;
+  theme: AppTheme;
+  useExtension: boolean;
+  isMobile: boolean;
+  maxRunner: number;
+  language: AppLanguage;
+  showTerminal: boolean;
+  privacy: boolean;
+  machineId: string;
+  downloadProxySwitch: boolean;
+  autoUpgrade: boolean;
+  allowBeta: boolean;
+  closeMainWindow: boolean;
+  audioMuted: boolean;
+  enableDocker: boolean;
+  dockerUrl: string;
+}
+
+export class ConversionRepository {}
+
+export class DownloadManagementService {}
+
+export class FavoriteManagementService {
+  getFavorites(): Favorite[] {
+    return [];
+  }
+
+  addFavorite(_favorite: Favorite): Favorite {
+    return _favorite;
+  }
+
+  removeFavorite(_id: number): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+export class TaskQueueService {
+  on(_event: string, _listener: (...args: unknown[]) => void): void {}
+}
+
+export class VideoRepository {}
+
+export const TYPES = {
+  Controller: Symbol("Controller"),
+  ConversionService: Symbol("ConversionService"),
+  DownloadManagementService: Symbol("DownloadManagementService"),
+  FavoriteManagementService: Symbol("FavoriteManagementService"),
+} as const;
+
+export function handle(_channel: string) {
+  return () => {
+    // no-op decorator for tests
+  };
+}

--- a/apps/backend-electron/src/controller/__tests__/HomeController.test.ts
+++ b/apps/backend-electron/src/controller/__tests__/HomeController.test.ts
@@ -1,0 +1,238 @@
+import "reflect-metadata";
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import type { AppLanguage } from "@mediago/shared-common";
+import { AppLanguage as LanguageEnum, AppTheme as ThemeEnum, i18n } from "@mediago/shared-common";
+import type {
+  AppStore,
+  ConversionRepository,
+  DownloadManagementService,
+  FavoriteManagementService,
+} from "@mediago/shared-node";
+import type { IpcMainEvent } from "electron";
+import { nativeTheme } from "electron";
+import HomeController from "../HomeController";
+import type WebviewService from "../../services/WebviewService";
+import type ElectronStore from "../../vendor/ElectronStore";
+import type ElectronLogger from "../../vendor/ElectronLogger";
+import type ElectronUpdater from "../../vendor/ElectronUpdater";
+import type BrowserWindow from "../../windows/BrowserWindow";
+import type MainWindow from "../../windows/MainWindow";
+
+class MockElectronStore {
+  public store: AppStore;
+
+  public readonly setCalls: Array<{
+    key: keyof AppStore;
+    value: AppStore[keyof AppStore];
+  }> = [];
+
+  constructor(initial?: Partial<AppStore>) {
+    this.store = {
+      local: "",
+      promptTone: true,
+      proxy: "",
+      useProxy: false,
+      deleteSegments: true,
+      openInNewWindow: false,
+      mainBounds: undefined,
+      browserBounds: undefined,
+      blockAds: true,
+      theme: ThemeEnum.System,
+      useExtension: false,
+      isMobile: false,
+      maxRunner: 2,
+      language: LanguageEnum.System,
+      showTerminal: false,
+      privacy: false,
+      machineId: "",
+      downloadProxySwitch: false,
+      autoUpgrade: true,
+      allowBeta: false,
+      closeMainWindow: false,
+      audioMuted: true,
+      enableDocker: false,
+      dockerUrl: "",
+      ...initial,
+    };
+  }
+
+  get<K extends keyof AppStore>(key: K): AppStore[K] {
+    return this.store[key];
+  }
+
+  set<K extends keyof AppStore>(key: K, value: AppStore[K]): void {
+    this.store[key] = value;
+    this.setCalls.push({ key, value });
+  }
+}
+
+class MockWebviewService {
+  public readonly proxyCalls: Array<[boolean, string]> = [];
+  public readonly blockingArgs: boolean[] = [];
+  public readonly userAgentArgs: boolean[] = [];
+  public readonly defaultSessionArgs: boolean[] = [];
+  public readonly audioMutedArgs: boolean[] = [];
+
+  setProxy(useProxy: boolean, proxy: string): void {
+    this.proxyCalls.push([useProxy, proxy]);
+  }
+
+  setBlocking(block: boolean): void {
+    this.blockingArgs.push(block);
+  }
+
+  setUserAgent(isMobile: boolean): void {
+    this.userAgentArgs.push(isMobile);
+  }
+
+  setDefaultSession(privacy: boolean): void {
+    this.defaultSessionArgs.push(privacy);
+  }
+
+  setAudioMuted(muted: boolean): void {
+    this.audioMutedArgs.push(muted);
+  }
+}
+
+class MockUpdater {
+  public readonly allowBetaArgs: boolean[] = [];
+
+  changeAllowBeta(allow: boolean): void {
+    this.allowBetaArgs.push(allow);
+  }
+}
+
+type ControllerDeps = {
+  store: MockElectronStore;
+  webviewService: MockWebviewService;
+  updater: MockUpdater;
+  controller: HomeController;
+  changeLanguageCalls: AppLanguage[];
+};
+
+describe("HomeController#setAppStore", () => {
+  let deps: ControllerDeps;
+  const noop = () => undefined;
+  const originalChangeLanguage = i18n.changeLanguage.bind(i18n);
+
+  beforeEach(() => {
+    const store = new MockElectronStore({ proxy: "http://proxy" });
+    const webviewService = new MockWebviewService();
+    const updater = new MockUpdater();
+    const changeLanguageCalls: AppLanguage[] = [];
+
+    (i18n as unknown as { changeLanguage: (lang: AppLanguage) => Promise<void> }).changeLanguage = async (
+      lang: AppLanguage,
+    ) => {
+      changeLanguageCalls.push(lang);
+    };
+
+    const controller = new HomeController(
+      store as unknown as ElectronStore,
+      {} as FavoriteManagementService,
+      { send: noop } as unknown as MainWindow,
+      {} as DownloadManagementService,
+      {} as BrowserWindow,
+      webviewService as unknown as WebviewService,
+      {} as ConversionRepository,
+      {} as ElectronLogger,
+      updater as unknown as ElectronUpdater,
+    );
+
+    deps = {
+      store,
+      webviewService,
+      updater,
+      controller,
+      changeLanguageCalls,
+    };
+  });
+
+  afterEach(() => {
+    (i18n as unknown as { changeLanguage: typeof originalChangeLanguage }).changeLanguage = originalChangeLanguage;
+    nativeTheme.themeSource = "system";
+  });
+
+  it("enables proxy by delegating to the webview service", async () => {
+    await deps.controller.setAppStore({} as IpcMainEvent, "useProxy", true);
+
+    assert.deepEqual(deps.webviewService.proxyCalls, [[true, "http://proxy"]]);
+    assert.equal(deps.store.store.useProxy, true);
+    assert.deepEqual(deps.store.setCalls, [{ key: "useProxy", value: true }]);
+  });
+
+  it("updates proxy details when proxy usage is already enabled", async () => {
+    deps.store.store.useProxy = true;
+
+    await deps.controller.setAppStore({} as IpcMainEvent, "proxy", "http://new");
+
+    assert.deepEqual(deps.webviewService.proxyCalls, [[true, "http://new"]]);
+    assert.equal(deps.store.store.proxy, "http://new");
+    assert.deepEqual(deps.store.setCalls, [{ key: "proxy", value: "http://new" }]);
+  });
+
+  it("does not trigger proxy updates when proxy usage is disabled", async () => {
+    await deps.controller.setAppStore({} as IpcMainEvent, "proxy", "http://new");
+
+    assert.deepEqual(deps.webviewService.proxyCalls, []);
+    assert.equal(deps.store.store.proxy, "http://new");
+  });
+
+  it("toggles ad blocking", async () => {
+    await deps.controller.setAppStore({} as IpcMainEvent, "blockAds", false);
+
+    assert.deepEqual(deps.webviewService.blockingArgs, [false]);
+    assert.equal(deps.store.store.blockAds, false);
+  });
+
+  it("switches theme via nativeTheme", async () => {
+    await deps.controller.setAppStore({} as IpcMainEvent, "theme", ThemeEnum.Dark);
+
+    assert.equal(nativeTheme.themeSource, ThemeEnum.Dark);
+    assert.equal(deps.store.store.theme, ThemeEnum.Dark);
+  });
+
+  it("updates the user agent when toggling mobile mode", async () => {
+    await deps.controller.setAppStore({} as IpcMainEvent, "isMobile", true);
+
+    assert.deepEqual(deps.webviewService.userAgentArgs, [true]);
+    assert.equal(deps.store.store.isMobile, true);
+  });
+
+  it("switches privacy mode", async () => {
+    await deps.controller.setAppStore({} as IpcMainEvent, "privacy", true);
+
+    assert.deepEqual(deps.webviewService.defaultSessionArgs, [true]);
+    assert.equal(deps.store.store.privacy, true);
+  });
+
+  it("changes language via i18n", async () => {
+    await deps.controller.setAppStore({} as IpcMainEvent, "language", LanguageEnum.EN);
+
+    assert.deepEqual(deps.changeLanguageCalls, [LanguageEnum.EN]);
+    assert.equal(deps.store.store.language, LanguageEnum.EN);
+  });
+
+  it("updates beta channel preference", async () => {
+    await deps.controller.setAppStore({} as IpcMainEvent, "allowBeta", true);
+
+    assert.deepEqual(deps.updater.allowBetaArgs, [true]);
+    assert.equal(deps.store.store.allowBeta, true);
+  });
+
+  it("toggles audio mute state", async () => {
+    await deps.controller.setAppStore({} as IpcMainEvent, "audioMuted", false);
+
+    assert.deepEqual(deps.webviewService.audioMutedArgs, [false]);
+    assert.equal(deps.store.store.audioMuted, false);
+  });
+
+  it("persists keys without handlers directly", async () => {
+    await deps.controller.setAppStore({} as IpcMainEvent, "promptTone", false);
+
+    assert.deepEqual(deps.webviewService.proxyCalls, []);
+    assert.deepEqual(deps.store.setCalls, [{ key: "promptTone", value: false }]);
+    assert.equal(deps.store.store.promptTone, false);
+  });
+});

--- a/apps/backend-electron/tsconfig.test.json
+++ b/apps/backend-electron/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "electron": ["./src/__mocks__/electron"],
+      "@mediago/shared-node": ["./src/__mocks__/shared-node"],
+      "electron-store": ["./src/__mocks__/electron-store"],
+      "fs-extra": ["./src/__mocks__/fs-extra"],
+      "electron-updater": ["./src/__mocks__/electron-updater"],
+      "node-machine-id": ["./src/__mocks__/node-machine-id"],
+      "electron-is-dev": ["./src/__mocks__/electron-is-dev"]
+    }
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- map app store keys to typed side-effect handlers and streamline persistence logic in `HomeController`
- add a test-only TypeScript config plus lightweight Electron and shared-node mocks so the controller can be exercised without the real runtime
- cover the mapped keys with node:test cases that assert each side effect and the persistence fallback for unmapped keys

## Testing
- `NODE_PATH=apps/backend-electron/src/__mocks__ TSX_TSCONFIG_PATH=apps/backend-electron/tsconfig.test.json pnpm exec tsx --test apps/backend-electron/src/controller/__tests__/HomeController.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68d28452f970832ba72914304de24185