### PR TITLE
refactor: rename remaining download item reference

### DIFF
--- a/apps/electron/src/app.ts
+++ b/apps/electron/src/app.ts
@@ -119,9 +119,9 @@ export default class ElectronApp {
   // If there are still videos being downloaded after the restart, change the status to download failed
   async resetDownloadStatus(): Promise<void> {
     // If data in the downloading state still fails after the restart, all downloads fail
-    const videos = await this.downloadTaskService.findWaitingAndDownloadingVideos();
+    const videos = await this.downloadTaskService.findActiveTasks();
     const videoIds = videos.map((video) => video.id);
-    await this.downloadTaskService.updateStatus(videoIds, DownloadStatus.Failed);
+    await this.downloadTaskService.setStatus(videoIds, DownloadStatus.Failed);
   }
 
   secondInstance = (event: Event, commandLine: string[]) => {

--- a/apps/electron/src/controller/download.controller.ts
+++ b/apps/electron/src/controller/download.controller.ts
@@ -41,8 +41,8 @@ export default class DownloadController implements Controller {
   }
 
   @handle(ADD_DOWNLOAD_ITEMS)
-  async addDownloadItems(e: IpcMainEvent, tasks: Omit<DownloadTask, "id">[], startDownload?: boolean) {
-    const items = await this.downloadTaskService.addDownloadTasks(tasks);
+  async createDownloadTasks(e: IpcMainEvent, tasks: Omit<DownloadTask, "id">[], startDownload?: boolean) {
+    const items = await this.downloadTaskService.createMany(tasks);
     // This sends a message to the page notifying it of the update
     this.mainWindow.send("download-item-notifier", items);
 
@@ -51,7 +51,7 @@ export default class DownloadController implements Controller {
       const local = this.store.get("local");
       const deleteSegments = this.store.get("deleteSegments");
       items.forEach((task) => {
-        this.downloadTaskService.startDownload(task.id, local, deleteSegments);
+        this.downloadTaskService.start(task.id, local, deleteSegments);
       });
     }
 
@@ -59,39 +59,39 @@ export default class DownloadController implements Controller {
   }
 
   @handle(EDIT_DOWNLOAD_ITEM)
-  async editDownloadItem(e: IpcMainEvent, task: DownloadTask, startDownload?: boolean) {
-    const item = await this.downloadTaskService.editDownloadTask(task);
+  async updateDownloadTask(e: IpcMainEvent, task: DownloadTask, startDownload?: boolean) {
+    const item = await this.downloadTaskService.update(task);
 
     // Start downloading immediately if requested
     if (startDownload) {
       const local = this.store.get("local");
       const deleteSegments = this.store.get("deleteSegments");
-      await this.downloadTaskService.startDownload(item.id, local, deleteSegments);
+      await this.downloadTaskService.start(item.id, local, deleteSegments);
     }
 
     return item;
   }
 
   @handle(GET_DOWNLOAD_ITEMS)
-  async getDownloadItems(e: IpcMainEvent, pagination: DownloadTaskPagination): Promise<ListPagination> {
+  async getDownloadTasks(e: IpcMainEvent, pagination: DownloadTaskPagination): Promise<ListPagination> {
     const local = this.store.get("local");
-    return await this.downloadTaskService.getDownloadTasks(pagination, local, videoPattern);
+    return await this.downloadTaskService.list(pagination, local, videoPattern);
   }
 
   @handle(START_DOWNLOAD)
-  async startDownload(e: IpcMainEvent, vid: number) {
+  async startDownloadTask(e: IpcMainEvent, vid: number) {
     const local = this.store.get("local");
     const deleteSegments = this.store.get("deleteSegments");
-    await this.downloadTaskService.startDownload(vid, local, deleteSegments);
+    await this.downloadTaskService.start(vid, local, deleteSegments);
   }
 
   @handle(STOP_DOWNLOAD)
-  async stopDownload(e: IpcMainEvent, id: number) {
-    this.downloadTaskService.stopDownload(id);
+  async stopDownloadTask(e: IpcMainEvent, id: number) {
+    this.downloadTaskService.stop(id);
   }
 
   @handle(DELETE_DOWNLOAD_ITEM)
-  async deleteDownloadItem(e: IpcMainEvent, id: number) {
-    return await this.downloadTaskService.deleteDownloadTask(id);
+  async deleteDownloadTask(e: IpcMainEvent, id: number) {
+    return await this.downloadTaskService.remove(id);
   }
 }

--- a/apps/electron/src/controller/home.controller.ts
+++ b/apps/electron/src/controller/home.controller.ts
@@ -233,7 +233,7 @@ export default class HomeController implements Controller {
         payload: id,
       });
     };
-    const item = await this.downloadTaskService.getDownloadTasks({ current: 1, pageSize: 1 }, this.store.get("local"), "");
+    const item = await this.downloadTaskService.list({ current: 1, pageSize: 1 }, this.store.get("local"), "");
     const task = item.list.find((t: any) => t.id === id);
     const template: Array<MenuItemConstructorOptions | MenuItem> = [
       {
@@ -337,7 +337,7 @@ export default class HomeController implements Controller {
 
   @handle(GET_DOWNLOAD_LOG)
   async getDownloadLog(event: IpcMainEvent, id: number) {
-    return await this.downloadTaskService.getDownloadLog(id);
+    return await this.downloadTaskService.getLog(id);
   }
 
   @handle(SELECT_FILE)
@@ -423,7 +423,7 @@ export default class HomeController implements Controller {
 
   @handle(EXPORT_DOWNLOAD_LIST)
   async exportDownloadList() {
-    const txt = await this.downloadTaskService.exportDownloadList();
+    const txt = await this.downloadTaskService.exportList();
     const window = this.mainWindow.window;
     if (!window) return Promise.reject(i18n.t("noMainWindow"));
 
@@ -440,7 +440,7 @@ export default class HomeController implements Controller {
 
   @handle(GET_VIDEO_FOLDERS)
   async getVideoFolders() {
-    return this.downloadTaskService.getTaskFolders();
+    return this.downloadTaskService.listFolders();
   }
 
   @handle(GET_PAGE_TITLE)

--- a/apps/electron/src/services/webview.service.ts
+++ b/apps/electron/src/services/webview.service.ts
@@ -155,7 +155,7 @@ export default class WebviewService {
       if (video) {
         item.name = `${item.name}-${Date.now()}`;
       }
-      const res = await this.downloadTaskService.addDownloadItem(item);
+      const res = await this.downloadTaskService.create(item);
       const mainWebContents = this.mainWindow.window?.webContents;
       if (!mainWebContents) return;
       // This sends a message to the page notifying it of the update

--- a/apps/electron/src/windows/main.window.ts
+++ b/apps/electron/src/windows/main.window.ts
@@ -63,7 +63,7 @@ export default class MainWindow extends Window {
 
   onDownloadReadyStart = async ({ id, isLive }: DownloadProgress) => {
     if (isLive) {
-      await this.downloadTaskService.updateIsLive(id, true);
+      await this.downloadTaskService.setIsLive(id, true);
     }
   };
 
@@ -128,7 +128,7 @@ export default class MainWindow extends Window {
 
   onDownloadSuccess = async (id: number) => {
     this.logger.info(`taskId: ${id} success`);
-    await this.downloadTaskService.updateStatus(id, DownloadStatus.Success);
+    await this.downloadTaskService.setStatus(id, DownloadStatus.Success);
     const video = await this.downloadTaskService.findByIdOrFail(id);
 
     const promptTone = this.store.get("promptTone");
@@ -151,7 +151,7 @@ export default class MainWindow extends Window {
 
   onDownloadFailed = async (id: number, err: unknown) => {
     this.logger.info(`taskId: ${id} failed`, err);
-    await this.downloadTaskService.updateStatus(id, DownloadStatus.Failed);
+    await this.downloadTaskService.setStatus(id, DownloadStatus.Failed);
 
     const promptTone = this.store.get("promptTone");
     if (promptTone) {
@@ -165,12 +165,12 @@ export default class MainWindow extends Window {
 
   onDownloadStart = async (id: number) => {
     this.logger.info(`taskId: ${id} start`);
-    await this.downloadTaskService.updateStatus(id, DownloadStatus.Downloading);
+    await this.downloadTaskService.setStatus(id, DownloadStatus.Downloading);
   };
 
   onDownloadStop = async (id: number) => {
     this.logger.info(`taskId: ${id} stopped`);
-    await this.downloadTaskService.updateStatus(id, DownloadStatus.Stopped);
+    await this.downloadTaskService.setStatus(id, DownloadStatus.Stopped);
   };
 
   onDownloadMessage = async (id: number, message: string) => {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -85,8 +85,8 @@ export default class ElectronApp extends Koa {
   // If there are still videos being downloaded after the restart, change the status to download failed
   async resetDownloadStatus(): Promise<void> {
     // If data in the downloading state still fails after the restart, all downloads fail
-    const videos = await this.downloadTaskService.findWaitingAndDownloadingVideos();
+    const videos = await this.downloadTaskService.findActiveTasks();
     const videoIds = videos.map((video) => video.id);
-    await this.downloadTaskService.updateStatus(videoIds, DownloadStatus.Failed);
+    await this.downloadTaskService.setStatus(videoIds, DownloadStatus.Failed);
   }
 }

--- a/apps/server/src/controller/downloader.controller.ts
+++ b/apps/server/src/controller/downloader.controller.ts
@@ -32,8 +32,8 @@ export default class DownloadController implements Controller {
   ) {}
 
   @handle(ADD_DOWNLOAD_ITEMS)
-  async addDownloadItems({ videos, startDownload }: { videos: Omit<DownloadTask, "id">[]; startDownload?: boolean }) {
-    const items = await this.downloadService.addDownloadItems(videos);
+  async createDownloadTasks({ videos, startDownload }: { videos: Omit<DownloadTask, "id">[]; startDownload?: boolean }) {
+    const items = await this.downloadService.createMany(videos);
 
     this.socket.refreshList();
 
@@ -42,7 +42,7 @@ export default class DownloadController implements Controller {
       const local = await this.store.get("local");
       const deleteSegments = await this.store.get("deleteSegments");
       items.forEach((item: any) => {
-        this.downloadService.startDownload(item.id, local, deleteSegments);
+        this.downloadService.start(item.id, local, deleteSegments);
       });
     }
 
@@ -50,45 +50,45 @@ export default class DownloadController implements Controller {
   }
 
   @handle(GET_DOWNLOAD_ITEMS)
-  async getDownloadItems(pagination: DownloadTaskPagination) {
+  async getDownloadTasks(pagination: DownloadTaskPagination) {
     const local = await this.store.get("local");
-    return await this.downloadService.getDownloadItems(pagination, local, "mp4,mkv,avi,mov,wmv,flv,webm,m4v");
+    return await this.downloadService.list(pagination, local, "mp4,mkv,avi,mov,wmv,flv,webm,m4v");
   }
 
   @handle(START_DOWNLOAD)
-  async startDownload({ vid }: { vid: number }) {
+  async startDownloadTask({ vid }: { vid: number }) {
     const local = await this.store.get("local");
     const deleteSegments = await this.store.get("deleteSegments");
-    await this.downloadService.startDownload(vid, local, deleteSegments);
+    await this.downloadService.start(vid, local, deleteSegments);
   }
 
   @handle(DELETE_DOWNLOAD_ITEM)
-  async deleteDownloadItem({ id }: { id: number }) {
-    await this.downloadService.deleteDownloadItem(id);
+  async deleteDownloadTask({ id }: { id: number }) {
+    await this.downloadService.remove(id);
   }
 
   @handle(EDIT_DOWNLOAD_ITEM)
-  async editDownloadItem({ video, startDownload }: { video: DownloadTask; startDownload?: boolean }) {
-    this.logger.info("editDownloadItem", video);
-    const item = await this.downloadService.editDownloadItem(video);
+  async updateDownloadTask({ video, startDownload }: { video: DownloadTask; startDownload?: boolean }) {
+    this.logger.info("editDownloadTask", video);
+    const item = await this.downloadService.update(video);
 
     // Start downloading immediately if requested
     if (startDownload) {
       const local = await this.store.get("local");
       const deleteSegments = await this.store.get("deleteSegments");
-      await this.downloadService.startDownload(item.id, local, deleteSegments);
+      await this.downloadService.start(item.id, local, deleteSegments);
     }
 
     return item;
   }
 
   @handle(STOP_DOWNLOAD)
-  async stopDownload({ id }: { id: number }) {
-    this.downloadService.stopDownload(id);
+  async stopDownloadTask({ id }: { id: number }) {
+    this.downloadService.stop(id);
   }
 
   @handle(GET_VIDEO_FOLDERS)
   async getVideoFolders() {
-    return this.downloadService.getVideoFolders();
+    return this.downloadService.listFolders();
   }
 }

--- a/apps/server/src/vendor/SocketIO.ts
+++ b/apps/server/src/vendor/SocketIO.ts
@@ -44,7 +44,7 @@ export default class SocketIO implements Vendor {
 
   onDownloadReadyStart = async ({ id, isLive }: DownloadProgress) => {
     if (isLive) {
-      await this.downloadTaskService.updateIsLive(id, true);
+      await this.downloadTaskService.setIsLive(id, true);
     }
   };
 

--- a/apps/ui/src/components/download-form.tsx
+++ b/apps/ui/src/components/download-form.tsx
@@ -61,7 +61,7 @@ export default forwardRef<DownloadFormRef, DownloadFormProps>(function DownloadF
   const { setLastDownloadTypes, setLastIsBatch } = useConfigStore(useShallow(downloadFormSelector));
   const [folders, setFolders] = useState<Options[]>([]);
   const [videoFolders, setVideoFolders] = useState<string[]>([]);
-  const { addDownloadItems, getVideoFolders } = useAPI();
+  const { createDownloadTasks, getVideoFolders } = useAPI();
   const { addVideosToDocker } = useDockerApi();
 
   useAsyncEffect(async () => {
@@ -119,7 +119,7 @@ export default forwardRef<DownloadFormRef, DownloadFormProps>(function DownloadF
 
     try {
       const tasks = await getFormItems();
-      await addDownloadItems(tasks);
+      await createDownloadTasks(tasks);
       setModalOpen(false);
       tdApp.onEvent(ADD_TO_LIST, { id });
     } catch (e: any) {
@@ -153,7 +153,7 @@ export default forwardRef<DownloadFormRef, DownloadFormProps>(function DownloadF
     }
     try {
       const tasks = await getFormItems();
-      await addDownloadItems(tasks, true);
+      await createDownloadTasks(tasks, true);
       setModalOpen(false);
       tdApp.onEvent(DOWNLOAD_NOW, { id });
     } catch (e: any) {

--- a/apps/ui/src/hooks/adapters/server.ts
+++ b/apps/ui/src/hooks/adapters/server.ts
@@ -72,10 +72,10 @@ export const webAdapter: ElectronApi = {
   openDir: async () => {
     return defaultResp;
   },
-  addDownloadItems: async (items: Omit<DownloadTask, "id">[], startDownload?: boolean) => {
+  createDownloadTasks: async (items: Omit<DownloadTask, "id">[], startDownload?: boolean) => {
     return api.post(ADD_DOWNLOAD_ITEMS, { videos: items, startDownload });
   },
-  getDownloadItems: async (p: DownloadTaskPagination) => {
+  getDownloadTasks: async (p: DownloadTaskPagination) => {
     return api.post(GET_DOWNLOAD_ITEMS, p);
   },
   startDownload: async (vid: number) => {
@@ -93,7 +93,7 @@ export const webAdapter: ElectronApi = {
   onFavoriteItemContextMenu: async () => {
     return defaultResp;
   },
-  deleteDownloadItem: async (id: number) => {
+  deleteDownloadTask: async (id: number) => {
     return api.post(DELETE_DOWNLOAD_ITEM, { id });
   },
   convertToAudio: async () => {
@@ -120,7 +120,7 @@ export const webAdapter: ElectronApi = {
   combineToHomePage: async () => {
     return defaultResp;
   },
-  editDownloadItem: async (video: DownloadTask, startDownload?: boolean) => {
+  updateDownloadTask: async (video: DownloadTask, startDownload?: boolean) => {
     return api.post(EDIT_DOWNLOAD_ITEM, { video, startDownload });
   },
   getLocalIP: async () => {

--- a/apps/ui/src/hooks/use-tasks.ts
+++ b/apps/ui/src/hooks/use-tasks.ts
@@ -4,7 +4,7 @@ import useSWR from "swr";
 import useAPI from "./use-api";
 
 export function useTasks(filter: DownloadFilter = DownloadFilter.list) {
-  const { getDownloadItems } = useAPI();
+  const { getDownloadTasks } = useAPI();
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
 
@@ -18,7 +18,7 @@ export function useTasks(filter: DownloadFilter = DownloadFilter.list) {
       },
     },
     ({ args }) => {
-      return getDownloadItems(args);
+      return getDownloadTasks(args);
     },
   );
 

--- a/apps/ui/src/pages/home-page/components/download-list.tsx
+++ b/apps/ui/src/pages/home-page/components/download-list.tsx
@@ -39,7 +39,7 @@ export function DownloadTaskList({ data, filter, refresh, loading }: Props) {
     removeIpcListener,
     stopDownload,
     onDownloadListContextMenu,
-    deleteDownloadItem,
+    deleteDownloadTask,
   } = useAPI();
   const { message } = App.useApp();
   const { t } = useTranslation();
@@ -127,7 +127,7 @@ export function DownloadTaskList({ data, filter, refresh, loading }: Props) {
       } else if (action === "refresh") {
         refresh();
       } else if (action === "delete") {
-        await deleteDownloadItem(payload);
+        await deleteDownloadTask(payload);
         refresh();
       }
     };
@@ -236,7 +236,7 @@ export function DownloadTaskList({ data, filter, refresh, loading }: Props) {
 
   const onDeleteItems = useMemoizedFn(async (ids: number[]) => {
     for (const id of ids) {
-      await deleteDownloadItem(Number(id));
+      await deleteDownloadTask(Number(id));
     }
     setSelected([]);
     refresh();

--- a/apps/ui/src/pages/home-page/index.tsx
+++ b/apps/ui/src/pages/home-page/index.tsx
@@ -26,7 +26,14 @@ interface Props {
 }
 
 const HomePage: FC<Props> = ({ filter = DownloadFilter.list }) => {
-  const { openDir, showBrowserWindow, addDownloadItems, getLocalIP, addIpcListener, removeIpcListener } = useAPI();
+  const {
+    openDir,
+    showBrowserWindow,
+    createDownloadTasks,
+    getLocalIP,
+    addIpcListener,
+    removeIpcListener,
+  } = useAPI();
   const appStore = useAppStore(useShallow(appStoreSelector));
   const { t } = useTranslation();
   const [localIP, setLocalIP] = useState<string>("");
@@ -57,7 +64,7 @@ const HomePage: FC<Props> = ({ filter = DownloadFilter.list }) => {
           headers,
           folder: "",
         };
-        addDownloadItems([item], true);
+        createDownloadTasks([item], true);
       } else {
         const item: DownloadFormItem = {
           batch: false,

--- a/apps/ui/src/pages/source-extract/components/browser-view-panel.tsx
+++ b/apps/ui/src/pages/source-extract/components/browser-view-panel.tsx
@@ -24,7 +24,7 @@ export function BrowserViewPanel() {
     useShallow(setBrowserSelector)
   );
   const { t } = useTranslation();
-  const { showDownloadDialog, addDownloadItems } = useAPI();
+  const { showDownloadDialog, createDownloadTasks } = useAPI();
   const { message } = App.useApp();
 
   const handleClear = useMemoizedFn(() => {
@@ -33,14 +33,14 @@ export function BrowserViewPanel() {
 
   const handleDownloadNow = useMemoizedFn(async (item: SourceData) => {
     try {
-      const downloadItem: Omit<DownloadTask, "id"> = {
+      const downloadTask: Omit<DownloadTask, "id"> = {
         url: item.url,
         name: item.name,
         headers: item.headers,
         type: item.type,
         folder: "",
       };
-      await addDownloadItems([downloadItem], true);
+      await createDownloadTasks([downloadTask], true);
     } catch (e) {
       message.error((e as any).message);
     }

--- a/packages/electron-preload/src/index.ts
+++ b/packages/electron-preload/src/index.ts
@@ -103,10 +103,10 @@ const electronApi: ElectronApi = {
     if (!dir) return;
     return ipcRenderer.invoke(OPEN_DIR, dir);
   },
-  addDownloadItems(videos: Omit<DownloadTask, "id">[], startDownload?: boolean): Promise<Video[]> {
+  createDownloadTasks(videos: Omit<DownloadTask, "id">[], startDownload?: boolean): Promise<Video[]> {
     return ipcRenderer.invoke(ADD_DOWNLOAD_ITEMS, videos, startDownload);
   },
-  getDownloadItems(p: DownloadTaskPagination): Promise<DownloadTaskResponse> {
+  getDownloadTasks(p: DownloadTaskPagination): Promise<DownloadTaskResponse> {
     return ipcRenderer.invoke(GET_DOWNLOAD_ITEMS, p);
   },
   startDownload(vid: number): Promise<void> {
@@ -124,7 +124,7 @@ const electronApi: ElectronApi = {
   onFavoriteItemContextMenu(id: number): Promise<void> {
     return ipcRenderer.invoke(ON_FAVORITE_ITEM_CONTEXT_MENU, id);
   },
-  deleteDownloadItem(id: number): Promise<void> {
+  deleteDownloadTask(id: number): Promise<void> {
     return ipcRenderer.invoke(DELETE_DOWNLOAD_ITEM, id);
   },
   convertToAudio(id: number): Promise<void> {
@@ -156,7 +156,7 @@ const electronApi: ElectronApi = {
   combineToHomePage(store: BrowserStore): Promise<void> {
     return ipcRenderer.invoke(COMBINE_TO_HOME_PAGE, store);
   },
-  editDownloadItem(video: DownloadTask, startDownload?: boolean): Promise<void> {
+  updateDownloadTask(video: DownloadTask, startDownload?: boolean): Promise<void> {
     return ipcRenderer.invoke(EDIT_DOWNLOAD_ITEM, video, startDownload);
   },
   getLocalIP(): Promise<string> {

--- a/packages/shared/common/src/types/electronApi.ts
+++ b/packages/shared/common/src/types/electronApi.ts
@@ -17,14 +17,14 @@ export interface ElectronApi {
   onSelectDownloadDir(): Promise<string>;
   setAppStore(key: keyof AppStore, val: AppStore[keyof AppStore]): Promise<void>;
   openDir(dir?: string): Promise<void>;
-  addDownloadItems(tasks: Omit<DownloadTask, "id">[], startDownload?: boolean): Promise<Video[]>;
-  getDownloadItems(p: DownloadTaskPagination): Promise<DownloadTaskResponse>;
+  createDownloadTasks(tasks: Omit<DownloadTask, "id">[], startDownload?: boolean): Promise<Video[]>;
+  getDownloadTasks(p: DownloadTaskPagination): Promise<DownloadTaskResponse>;
   startDownload(vid: number): Promise<void>;
   openUrl(url: string): Promise<void>;
   stopDownload(id: number): Promise<void>;
   onDownloadListContextMenu(id: number): Promise<void>;
   onFavoriteItemContextMenu(id: number): Promise<void>;
-  deleteDownloadItem(id: number): Promise<void>;
+  deleteDownloadTask(id: number): Promise<void>;
   convertToAudio(id: number): Promise<void>;
   rendererEvent(
     channel: string,
@@ -37,7 +37,7 @@ export interface ElectronApi {
   webviewShow(): Promise<void>;
   webviewUrlContextMenu(): Promise<void>;
   combineToHomePage(store: BrowserStore): Promise<void>;
-  editDownloadItem(task: DownloadTask, startDownload?: boolean): Promise<void>;
+  updateDownloadTask(task: DownloadTask, startDownload?: boolean): Promise<void>;
   getLocalIP(): Promise<string>;
   openBrowser(url: string): Promise<void>;
   selectFile(): Promise<string>;

--- a/packages/shared/node/src/services/download-task.service.ts
+++ b/packages/shared/node/src/services/download-task.service.ts
@@ -34,19 +34,19 @@ export class DownloadTaskService {
     private readonly downloaderServer: DownloaderServer,
   ) {}
 
-  async addDownloadTask(task: Omit<DownloadTask, "id">) {
+  async create(task: Omit<DownloadTask, "id">) {
     return await this.downloadTaskRepository.create(task);
   }
 
-  async addDownloadTasks(tasks: Omit<DownloadTask, "id">[]) {
+  async createMany(tasks: Omit<DownloadTask, "id">[]) {
     return await this.downloadTaskRepository.createMany(tasks);
   }
 
-  async editDownloadTask(task: DownloadTask) {
+  async update(task: DownloadTask) {
     return await this.downloadTaskRepository.update(task.id, task);
   }
 
-  async getDownloadTasks(
+  async list(
     pagination: DownloadTaskPagination,
     localPath: string,
     videoPattern: string,
@@ -72,7 +72,7 @@ export class DownloadTaskService {
     };
   }
 
-  async startDownload(taskId: number, localPath: string, deleteSegments: boolean) {
+  async start(taskId: number, localPath: string, deleteSegments: boolean) {
     const task = await this.downloadTaskRepository.findByIdOrFail(taskId);
     const { name, url, type, folder } = task;
 
@@ -89,34 +89,34 @@ export class DownloadTaskService {
     });
   }
 
-  async stopDownload(id: number) {
+  async stop(id: number) {
     this.downloaderServer.stopTask(id.toString());
   }
 
-  async deleteDownloadTask(id: number) {
+  async remove(id: number) {
     return await this.downloadTaskRepository.delete(id);
   }
 
-  async getDownloadLog(id: number) {
+  async getLog(id: number) {
     const task = await this.downloadTaskRepository.findByIdOrFail(id);
     return task.log || "";
   }
 
-  async getTaskFolders() {
+  async listFolders() {
     return this.downloadTaskRepository.findDistinctFolders();
   }
 
-  async exportDownloadList() {
+  async exportList() {
     const tasks = await this.downloadTaskRepository.findAll("DESC");
     return tasks.map((task) => `${task.url} ${task.name}`).join("\n");
   }
 
   // Status update methods
-  async updateStatus(ids: number | number[], status: DownloadStatus): Promise<void> {
+  async setStatus(ids: number | number[], status: DownloadStatus): Promise<void> {
     await this.downloadTaskRepository.updateStatus(ids, status);
   }
 
-  async updateIsLive(id: number, isLive: boolean = true): Promise<void> {
+  async setIsLive(id: number, isLive: boolean = true): Promise<void> {
     await this.downloadTaskRepository.updateIsLive(id, isLive);
   }
 
@@ -141,41 +141,60 @@ export class DownloadTaskService {
     return await this.downloadTaskRepository.findByUrl(url);
   }
 
-  async findWaitingAndDownloadingTasks() {
+  async findActiveTasks() {
     return await this.downloadTaskRepository.findByStatus([DownloadStatus.Watting, DownloadStatus.Downloading]);
   }
 
-  // Alias method (deprecated, use findWaitingAndDownloadingTasks instead)
+  // Legacy aliases (deprecated)
+  async findWaitingAndDownloadingTasks() {
+    return await this.findActiveTasks();
+  }
+
   async findWaitingAndDownloadingVideos() {
-    return await this.findWaitingAndDownloadingTasks();
+    return await this.findActiveTasks();
   }
 
-  // Alias methods (deprecated)
-  async addDownloadItem(task: Omit<DownloadTask, "id">) {
-    return await this.addDownloadTask(task);
+  async addDownloadTask(task: Omit<DownloadTask, "id">) {
+    return await this.create(task);
   }
 
-  async addDownloadItems(tasks: Omit<DownloadTask, "id">[]) {
-    return await this.addDownloadTasks(tasks);
+  async addDownloadTasks(tasks: Omit<DownloadTask, "id">[]) {
+    return await this.createMany(tasks);
   }
 
-  async getDownloadItems(
+  async editDownloadTask(task: DownloadTask) {
+    return await this.update(task);
+  }
+
+  async getDownloadTasks(
     pagination: DownloadTaskPagination,
     localPath: string,
     videoPattern: string,
   ): Promise<ListPagination> {
-    return await this.getDownloadTasks(pagination, localPath, videoPattern);
+    return await this.list(pagination, localPath, videoPattern);
   }
 
-  async deleteDownloadItem(id: number) {
-    return await this.deleteDownloadTask(id);
+  async startDownload(taskId: number, localPath: string, deleteSegments: boolean) {
+    return await this.start(taskId, localPath, deleteSegments);
   }
 
-  async editDownloadItem(task: DownloadTask) {
-    return await this.editDownloadTask(task);
+  async stopDownload(id: number) {
+    return await this.stop(id);
   }
 
-  async getVideoFolders() {
-    return await this.getTaskFolders();
+  async deleteDownloadTask(id: number) {
+    return await this.remove(id);
+  }
+
+  async getDownloadLog(id: number) {
+    return await this.getLog(id);
+  }
+
+  async getTaskFolders() {
+    return await this.listFolders();
+  }
+
+  async exportDownloadList() {
+    return await this.exportList();
   }
 }


### PR DESCRIPTION
## Summary
- rename the remaining BrowserViewPanel helper variable from downloadItem to downloadTask for consistency with the service API updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68efeb8705a0832badd4e3b4894692c4