### PR TITLE
fix: upgrade zustand to stable and fix broken player build scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,8 @@ pnpm build:electron         # Production build for Electron
 pnpm build:web              # Build UI only (server mode)
 pnpm core:dev               # Start Go Core dev server (port 9900)
 pnpm core:build             # Compile Go Core binary
-pnpm player:dev             # Start Player dev (Go backend + UI)
-pnpm player:build           # Build Player (UI embedded in Go binary)
+pnpm player:dev             # Start Player dev (alias for core:dev)
+pnpm player:build           # Build Player (alias for core:build)
 pnpm deps:download          # Download third-party tools (ffmpeg, BBDown, etc.)
 pnpm deps:download:all      # Download tools for all platforms
 pnpm lint                   # Lint with oxlint

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -44,7 +44,7 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
-    "zustand": "5.0.0-rc.2"
+    "zustand": "^5.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.14",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "type:check": "turbo type:check",
     "core:dev": "pnpm --filter @mediago/core-build run dev",
     "core:build": "pnpm --filter @mediago/core-build run build",
-    "player:dev": "pnpm --filter @mediago/player-build run dev",
-    "player:build": "pnpm --filter @mediago/player-build run build",
+    "player:dev": "pnpm --filter @mediago/core-build run dev",
+    "player:build": "pnpm --filter @mediago/core-build run build",
     "deps:download": "tsx scripts/download-deps.ts",
     "deps:download:all": "tsx scripts/download-deps.ts --all",
     "prepare": "husky"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,8 +366,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       zustand:
-        specifier: 5.0.0-rc.2
-        version: 5.0.0-rc.2(@types/react@19.2.14)(immer@10.2.0)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+        specifier: ^5.0.0
+        version: 5.0.12(@types/react@19.2.14)(immer@10.2.0)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.1.14
@@ -6959,8 +6959,8 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
-  zustand@5.0.0-rc.2:
-    resolution: {integrity: sha512-o2Nwuvnk8vQBX7CcHL8WfFkZNJdxB/VKeWw0tNglw8p4cypsZ3tRT7rTRTDNeUPFS0qaMBRSKe+fVwL5xpcE3A==}
+  zustand@5.0.12:
+    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=18.0.0'
@@ -13628,7 +13628,7 @@ snapshots:
 
   zod@4.3.6: {}
 
-  zustand@5.0.0-rc.2(@types/react@19.2.14)(immer@10.2.0)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+  zustand@5.0.12(@types/react@19.2.14)(immer@10.2.0)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
     optionalDependencies:
       '@types/react': 19.2.14
       immer: 10.2.0


### PR DESCRIPTION
- Upgrade zustand from 5.0.0-rc.2 to ^5.0.0 (resolved 5.0.12)
- Fix player:dev and player:build scripts that referenced non-existent @mediago/player-build, now correctly point to @mediago/core-build

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>