### PR TITLE
fix(installer): show version in title bar, set installer FileDescription (#637)

### DIFF
--- a/apps/electron/installer/installer.nsh
+++ b/apps/electron/installer/installer.nsh
@@ -1,0 +1,56 @@
+; ============================================================================
+; Custom NSIS overrides injected by electron-builder.
+;
+; electron-builder splices `!insertmacro customHeader` into the top of its
+; generated installer script (see
+; node_modules/app-builder-lib/templates/nsis/installer.nsi around line 45),
+; which is AFTER `common.nsh` is included. That makes this macro the right
+; place to override directives like `Name`, `Caption`, `BrandingText`.
+;
+; Note on FileDescription: we intentionally do NOT override it here.
+; electron-builder's `NsisTarget.computeVersionKey()` (app-builder-lib ->
+; out/targets/nsis/NsisTarget.js) unconditionally emits
+;   VIAddVersionKey /LANG=1033 "FileDescription" "${appInfo.description}"
+; from `apps/electron/app/package.json`'s `description`. Any customHeader
+; VIAddVersionKey targeting the same LANG+key triggers a hard NSIS error
+; ("already defined!") that `-WX` does not gate. Different LANG (e.g. 0)
+; produces a `warning 9100: without standard key FileVersion` which IS
+; gated by -WX and still fails the build.
+;
+; The installer's FileDescription is rewritten post-build via `app-builder
+; rcedit` in `afterAllArtifactBuild` (see apps/electron/scripts/build.ts).
+; That sidesteps the NSIS constraint and lets the installer and app
+; binary carry distinct descriptions (like VS Code / Chrome's Inno Setup
+; default of "{AppName} Setup").
+;
+; Wired up through `nsis.include` in apps/electron/scripts/build.ts.
+; ============================================================================
+
+!macro customHeader
+  ; ---------------------------------------------------------------------
+  ; Surface the version in the installer's title bar.
+  ;
+  ; electron-builder's common.nsh sets `Name "${PRODUCT_NAME}"`, from
+  ; which NSIS derives the default `$(^SetupCaption)` (e.g. "Setup -
+  ; mediago-community"). That caption omits the version — users had to
+  ; look at the gray BrandingText at the bottom-left to see which
+  ; release they were installing.
+  ;
+  ; Why `Caption` and not `Name`: re-setting `Name` emits
+  ; `warning 6029: Name: specified multiple times`, and electron-builder
+  ; compiles NSIS with `-WX` (warnings-as-errors), so the build fails.
+  ;
+  ; Why a plain literal and not `$(^SetupCaption)`: the localized lang
+  ; string is evaluated at runtime via the MUI plugin. electron-builder
+  ; compiles an intermediate installer with `-DBUILD_UNINSTALLER` and
+  ; executes it silently (NsisTarget.js line ~370, `execWine(installerPath,
+  ; ..., __COMPAT_LAYER=RunAsInvoker)`) just to extract the uninstaller.
+  ; Evaluating a language string in the `Caption` directive during that
+  ; silent pass crashes with STATUS_STACK_BUFFER_OVERRUN (exit 3221225725)
+  ; and aborts the whole packaging. A plain literal sidesteps the MUI
+  ; runtime call entirely, so the intermediate pass finishes cleanly.
+  ; Trade-off: title bar reads "Setup - mediago-community 3.5.0" in every
+  ; locale instead of the translated "Installazione di ..." — acceptable.
+  ; ---------------------------------------------------------------------
+  Caption "Setup - ${PRODUCT_NAME} ${VERSION}"
+!macroend

--- a/apps/electron/scripts/build.ts
+++ b/apps/electron/scripts/build.ts
@@ -1,7 +1,10 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path, { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import dotenvFlow from "dotenv-flow";
 import { type Configuration, build } from "electron-builder";
 
@@ -13,6 +16,22 @@ const __dirname = dirname(__filename);
 const projectRoot = path.resolve(__dirname, "../../..");
 const appRoot = path.resolve(__dirname, "..");
 const arch = process.arch === "arm64" ? "arm64" : "x64";
+
+// Resolve electron-builder's bundled `app-builder` native helper
+// (wraps rcedit, ships inside `app-builder-bin`). We use it from
+// `afterAllArtifactBuild` below to rewrite the NSIS installer's
+// FileDescription — see the hook for why. `app-builder-bin` is
+// a transitive dep of electron-builder, not a direct one, so we
+// resolve it via nested `createRequire` scoped to electron-builder's
+// own location.
+const execFileAsync = promisify(execFile);
+const localRequire = createRequire(import.meta.url);
+const electronBuilderRequire = createRequire(
+  localRequire.resolve("electron-builder/package.json"),
+);
+const { appBuilderPath } = electronBuilderRequire("app-builder-bin") as {
+  appBuilderPath: string;
+};
 
 dotenvFlow.config({
   path: projectRoot,
@@ -156,6 +175,52 @@ function getReleaseConfig(): Configuration {
       allowToChangeInstallationDirectory: true,
       createDesktopShortcut: true,
       createStartMenuShortcut: true,
+      // Inject our customHeader macro to add the version to the
+      // installer title bar. See comments in
+      // `apps/electron/installer/installer.nsh`.
+      include: "./installer/installer.nsh",
+    },
+    // Rewrite the NSIS installer's `FileDescription` after the fact.
+    //
+    // Why this isn't done in the .nsh header: electron-builder's
+    // `NsisTarget.computeVersionKey()` unconditionally emits
+    //   VIAddVersionKey /LANG=1033 "FileDescription" "${appInfo.description}"
+    // into the generated .nsi — binding the installer's FileDescription
+    // to the app binary's (both drawn from `app/package.json:description`).
+    // Any customHeader `VIAddVersionKey` with the same LANG+key triggers
+    // a hard NSIS "already defined!" error that `-WX` does not gate, and
+    // a different LANG (e.g. 0) triggers `warning 9100: without standard
+    // key FileVersion` which IS gated by `-WX`. There is no in-NSIS way
+    // to override this cleanly.
+    //
+    // Inno Setup (used by VS Code, Chrome) gets this for free via a
+    // default `VersionInfoDescription = "{AppName} Setup"`. NSIS has no
+    // such default, so we post-process the artifact with the same
+    // `app-builder rcedit` call electron-builder itself uses on
+    // `mediago.exe` (see winPackager.js around line 185).
+    afterAllArtifactBuild: async ({ artifactPaths }) => {
+      // rcedit crashes when executed through Wine (per electron-builder's
+      // own note in winPackager.js:183); skip on Linux. Windows installer
+      // artifacts aren't produced on Linux builds anyway.
+      if (process.platform !== "win32" && process.platform !== "darwin") {
+        return [];
+      }
+      const installers = artifactPaths.filter((p) =>
+        /-setup-win32-.*\.exe$/i.test(path.basename(p)),
+      );
+      for (const installer of installers) {
+        await execFileAsync(appBuilderPath, [
+          "rcedit",
+          "--args",
+          JSON.stringify([
+            installer,
+            "--set-version-string",
+            "FileDescription",
+            `${process.env.APP_NAME} installer`,
+          ]),
+        ]);
+      }
+      return [];
     },
   };
 }


### PR DESCRIPTION
- `installer/installer.nsh`: customHeader macro sets Caption to "Setup - ${PRODUCT_NAME} ${VERSION}" so users can see which release they're installing from the window title (the default $(^SetupCaption) omits the version, and re-setting Name trips NSIS warning 6029 which electron-builder's -WX flag treats as a hard error).
- `scripts/build.ts`: afterAllArtifactBuild hook runs the app-builder rcedit helper on the generated NSIS installer to rewrite its FileDescription to "${APP_NAME} installer". electron-builder's NsisTarget.computeVersionKey() hardcodes VIAddVersionKey /LANG=1033 "FileDescription" "${appInfo.description}", binding the installer's FileDescription to the app binary's (both drawn from package.json description); any in-NSIS override collides on the same LANG+key with a hard "already defined!" error that -WX does not gate. Post-processing with rcedit sidesteps this and lets installer and app binary carry distinct descriptions — same approach VS Code's Inno Setup pipeline uses (where "{AppName} Setup" is the default).

Closes #637

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>