### PR TITLE
docs: add community links to readme

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -7,6 +7,10 @@
   <a href="https://downloader.caorushizi.cn/it/documents.html?form=github">Documentazione</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://github.com/caorushizi/mediago/discussions">Discussioni</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://discord.gg/yxWBVRWGqM">Discord</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://www.reddit.com/r/MediaGo_Studio/">Reddit</a>
   <br>
 
 <a href="https://github.com/caorushizi/mediago/blob/master/README.md">English</a>

--- a/README.jp.md
+++ b/README.jp.md
@@ -7,6 +7,10 @@
   <a href="https://downloader.caorushizi.cn/jp/documents.html?form=github">ドキュメント</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://github.com/caorushizi/mediago/discussions">Discussions</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://discord.gg/yxWBVRWGqM">Discord</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://www.reddit.com/r/MediaGo_Studio/">Reddit</a>
   <br>
 
 <a href="https://github.com/caorushizi/mediago/blob/master/README.md">English</a>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
   <a href="https://downloader.caorushizi.cn/en/documents.html?form=github">Docs</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://github.com/caorushizi/mediago/discussions">Discussions</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://discord.gg/yxWBVRWGqM">Discord</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://www.reddit.com/r/MediaGo_Studio/">Reddit</a>
   <br>
 
 <a href="https://github.com/caorushizi/mediago/blob/master/README.zh.md">中文</a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -7,6 +7,10 @@
   <a href="https://downloader.caorushizi.cn/documents.html?form=github">文档</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://github.com/caorushizi/mediago/discussions">Discussions</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://discord.gg/yxWBVRWGqM">Discord</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://www.reddit.com/r/MediaGo_Studio/">Reddit</a>
   <br>
 
 <a href="https://github.com/caorushizi/mediago/blob/master/README.md">English</a>


### PR DESCRIPTION
## Summary
- add Discord and Reddit links to the top navigation in all root README translations

## Tests
- not run (documentation-only change)