### PR TITLE
[codex] fix docs canonical site url

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,7 +4,7 @@ import { defineConfig, type HeadConfig } from "vitepress";
 import { baiduAnalytics, googleAnalytics } from "./plugins";
 
 const isDev = process.env.NODE_ENV === "development";
-const siteUrl = "https://mediago.torchstellar.com";
+const siteUrl = "https://downloader.caorushizi.cn";
 
 const head: HeadConfig[] = [
   ["link", { rel: "shortcut icon", href: "/favicon.svg" }],


### PR DESCRIPTION
## Summary
- Restore the docs canonical site URL to https://downloader.caorushizi.cn.
- This updates sitemap, canonical URLs, Open Graph URLs, hreflang alternates, and structured data generated from the shared siteUrl constant.

## Impact
- Docs-only config change.
- Prevents the MediaGo docs site from pointing canonical/search metadata at the MediaGo Pro domain.

## Validation
- pnpm -F @mediago/docs run docs:build
- Generated sitemap has 78 loc URLs under https://downloader.caorushizi.cn and 0 references to mediago.torchstellar.com
- git diff --check